### PR TITLE
re-arranged puv-html

### DIFF
--- a/nvsvocprez/view/templates/concept.html
+++ b/nvsvocprez/view/templates/concept.html
@@ -31,30 +31,6 @@
           <th><a href="http://purl.org/dc/terms/date">Date</a></th>
           <td colspan="2">{{ date }}</td>
         </tr>
-        {% if profile_token == "puv" %}
-          <tr>
-            <th colspan="3" style="padding-top:20px;"><a style="font-size: 22px;" href="https://w3id.org/env/puv">PUV Properties</a></th>
-          </tr>
-          {% if puv|length > 0 %}
-            {% for x in puv %}
-            <tr>
-              <th>{{ x.predicate_html|safe }}</th>
-              {{ x.object_html|safe }}
-            </tr>
-            {% endfor %}
-          {% endif %}
-          <tr>
-            <th colspan="3" style="padding-top:20px;"><span style="font-size: 22px;">NVS Properties</span></th>
-          </tr>
-        {% endif %}
-        {% if related|length > 0 %}
-          {% for x in related %}
-            <tr>
-              <th>{{ x.predicate_html|safe }}</th>
-              {{ x.object_html|safe }}
-            </tr>
-          {% endfor %}
-        {% endif %}
         {% if agent|length > 0 %}
           {% for x in agent %}
             <tr>
@@ -81,6 +57,30 @@
         {% endif %}
         {% if other|length > 0 %}
           {% for x in other %}
+            <tr>
+              <th>{{ x.predicate_html|safe }}</th>
+              {{ x.object_html|safe }}
+            </tr>
+          {% endfor %}
+        {% endif %}
+        {% if profile_token == "puv" %}
+          <tr>
+            <th colspan="3" style="padding-top:20px;"><a style="font-size: 22px;" href="https://w3id.org/env/puv">PUV Properties</a></th>
+          </tr>
+          {% if puv|length > 0 %}
+            {% for x in puv %}
+            <tr>
+              <th>{{ x.predicate_html|safe }}</th>
+              {{ x.object_html|safe }}
+            </tr>
+            {% endfor %}
+          {% endif %}
+          <tr>
+            <th colspan="3" style="padding-top:20px;"><span style="font-size: 22px;">NVS Properties</span></th>
+          </tr>
+        {% endif %}
+        {% if related|length > 0 %}
+          {% for x in related %}
             <tr>
               <th>{{ x.predicate_html|safe }}</th>
               {{ x.object_html|safe }}


### PR DESCRIPTION
The PUV section of the concepts HTML template has been re-arranged as requested from Alex/Gwen.

Properties following 'Related' have been moved up to display directly below the main 'Date' property:

![image](https://user-images.githubusercontent.com/64262641/136230912-2b9e06ab-1445-4bf8-ad12-f3930430afa7.png)
