### PR TITLE
Feature/access to html concept level buttons

### DIFF
--- a/nvsvocprez/app.py
+++ b/nvsvocprez/app.py
@@ -617,16 +617,6 @@ def collection(request: Request, collection_id, acc_dep_or_concept: str = None):
                                 "message": "There was an error with accessing the Triplestore",
                             },
                         )
-        
-                    print("AAAAAAAAAAAAAAAAAAAAAAAAA")
-
-                    #print(self.profile)
-                    print(self.alt_profiles)
-                    #print(collection.conforms_to)
-
-                    print("AAAAAAAAAAAAAAAAAAAAAAAAA")
-
-
                     return templates.TemplateResponse(
                         "collection.html",
                         {
@@ -1549,6 +1539,7 @@ class ConceptRenderer(Renderer):
               BIND (COALESCE(?x, "Climate and Forecast Standard Names") AS ?collection_label)
             }}         
         """
+
         r = sparql_query(q)
         if not r[0]:
             return PlainTextResponse(
@@ -1616,6 +1607,8 @@ class ConceptRenderer(Renderer):
             "provenance": [],
             "other": [],
             "profile_token": self.profile,
+            "alt_profiles": self.alt_profiles,
+            "profile_properties_for_button": [],
         }
 
         def make_predicate_label_from_uri(uri):
@@ -1623,6 +1616,7 @@ class ConceptRenderer(Renderer):
 
         alt_profiles = get_alt_profiles()
         profile_url = None
+
         for ap in alt_profiles.values():
             if ap["token"] == self.profile:
                 profile_url = ap["url"]
@@ -1635,6 +1629,7 @@ class ConceptRenderer(Renderer):
             o_notation = (
                 x["o_notation"]["value"] if x.get("o_notation") is not None else None
             )
+
             context["collection_systemUri"] = x["collection_systemUri"]["value"]
             context["collection_label"] = x["collection_label"]["value"]
             if p == str(OWL.deprecated):
@@ -1657,6 +1652,7 @@ class ConceptRenderer(Renderer):
                 p_label = p[len(profile_url):]
                 if p_label[0] == "#":
                     p_label = p_label[1:]
+
                 context["profile_properties"].append(
                     DisplayProperty(p, p_label, o, o_label, o_notation)
                 )
@@ -1687,7 +1683,7 @@ class ConceptRenderer(Renderer):
         context["other"].sort(key=lambda x: x.predicate_html)
         clean_prop_list_labels(context["other"])
 
-        q = f"""
+        q1 = f"""
              PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
              PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
              PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -1703,14 +1699,59 @@ class ConceptRenderer(Renderer):
             }}
             group by ?uri ?id ?systemUri
          """        
-        r = sparql_query(q)
+        r1 = sparql_query(q1)
 
-        context["conforms_to"] = None 
+        q2 = f"""
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+            PREFIX owl: <http://www.w3.org/2002/07/owl#>
+            SELECT DISTINCT ?p ?o ?o_label ?o_notation ?collection_uri ?collection_systemUri ?collection_label
+            WHERE {{
+              BIND (<{self.instance_uri}> AS ?concept)
+              ?concept ?p ?o .
 
-        for item in r[1]:
+              FILTER ( ?p != skos:broaderTransitive )
+              FILTER ( ?p != skos:narrowerTransitive )
+              FILTER ( ?p != skos:broader )
+              FILTER ( ?p != skos:narrower )
+              FILTER ( ?p != skos:related )
+              FILTER ( ?p != owl:sameAs )
+              FILTER(!isLiteral(?o) || lang(?o) = "en" || lang(?o) = "")
+
+              OPTIONAL {{
+                ?o skos:prefLabel ?o_label ;
+                   skos:notation ?o_notation .
+                FILTER(!isLiteral(?o_label) || lang(?o_label) = "en" || lang(?o_label) = "")
+              }}
+
+              BIND(
+                IF(
+                  CONTAINS(STR(?concept), "standard_name"),
+                    <{DATA_URI}/standard_name/>,
+                    IRI(CONCAT(STRBEFORE(STR(?concept), "/current/"), "/current/"))
+                )
+                AS ?collection_uri
+              )
+              BIND (REPLACE(STR(?collection_uri), "{DATA_URI}", "") AS ?collection_systemUri)
+              OPTIONAL {{?collection_uri skos:prefLabel ?x }}
+              BIND (COALESCE(?x, "Climate and Forecast Standard Names") AS ?collection_label)
+            }}
+        """
+
+        r2 = sparql_query(q2)
+
+        p_keys = [x["p"]["value"] for x in r2[1]]
+
+        context["conforms_to"] = [] 
+
+        for item in r1[1]:
            if 'conforms_to' in item and item['systemUri']['value'] in context["uri"]:
-             context["conforms_to"] = item['conforms_to']['value'] 
-             break 
+             c = item['conforms_to']['value'].split(",")
+             for c_item in c:
+               match = any(c_item in s for s in p_keys) 
+               if match: context["conforms_to"].append(c_item)  
+
+        # print(context["conforms_to"]) # used to build required butons on concept page for access to HTML alt profile view 
 
         return templates.TemplateResponse("concept.html", context=context)
 

--- a/nvsvocprez/view/templates/concept.html
+++ b/nvsvocprez/view/templates/concept.html
@@ -86,6 +86,22 @@
         {% endif %}
       </table>
     </div>
-    {% include 'alt_link.html' %}
+
+    <div style="grid-column: 2; grid-row: 1;">
+      {% include 'alt_link.html' %}
+      {% if conforms_to is defined and conforms_to is not none %}
+        <div>
+        {% for profile in conforms_to %}
+            {% if profile in alt_profiles %}
+              {% set alt = alt_profiles[profile] %}
+              <p>
+                <a class="format-button" style="width:200px;" href="?_profile={{ alt['token'] }}&_mediatype=text/html">{{ alt['description'] }}</a>
+                <span class="tooltip" style="font-weight:bold;">?<span class="tooltiptext">{{ alt['description'] }} HTML view.</span></span>
+              </p>
+            {% endif %}
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
The alternative profile buttons at the concept page is built using the conforms_to (same as on collection page). The conforms_to is only availble on the collections route in the codebase so a sparql query has been added to retrieve the conforms_to for the concept route.

A further sparql query has been written to retrieve the profile properties for the concept which is used to exclude the profile button if there are no profile properties associated with the concept.